### PR TITLE
Github Codespace Support Began

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
 ENV LANG C.UTF-8
 ARG INSTALL_ZSH="true"
 
-RUN apt-get update
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive
 #install sbt
 RUN sudo apt-get install apt-transport-https curl gnupg -yqq
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
@@ -13,4 +13,4 @@ RUN sudo chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
 RUN sudo apt-get update
 RUN sudo apt-get install sbt
 #Install everything else
-RUN apt-get -y install openjdk-17-jdk
+RUN apt-get -y install openjdk-17-jdk gtkwave

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
+
+ENV LANG C.UTF-8
+ARG INSTALL_ZSH="true"
+
+RUN apt-get update
+#install sbt
+RUN sudo apt-get install apt-transport-https curl gnupg -yqq
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo -H gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
+RUN sudo chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
+RUN sudo apt-get update
+RUN sudo apt-get install sbt
+#Install everything else
+RUN apt-get -y install openjdk-17-jdk

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+    "build": { "dockerfile": "Dockerfile" },
+    "features": {
+    },
+    "customizations": {
+      "vscode": {
+      "extensions": [
+        "scala-lang.scala",
+        "scalameta.metals",
+        "wavetrace.wavetrace",
+        "itryapitsin.Sbt",
+        "shd101wyy.markdown-preview-enhanced",
+        "GitHub.vscode-github-actions",
+        "ms-azuretools.vscode-docker"
+    ]
+      }
+    }
+  }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,13 @@
 {
     "build": { "dockerfile": "Dockerfile" },
     "features": {
+      "ghcr.io/devcontainers/features/desktop-lite:1": {}
+    },
+    "forwardPorts": [6080],
+    "portsAttributes": {
+      "6080": {
+        "label": "desktop"
+      }
     },
     "customizations": {
       "vscode": {


### PR DESCRIPTION
Added .devcontainer to create a Github Codespace with sbt install with VSCode for the web with recommended extensions install such as SBT Metals and Wavetrace.